### PR TITLE
Fix some minor bugs in the clotho_preprocessing script

### DIFF
--- a/clotho_preprocessing.py
+++ b/clotho_preprocessing.py
@@ -36,7 +36,7 @@ def preprocess_dataset(config):
                     assert(len(r)==6) # Ensure captions and filename are parsed correctly
                     example_list.append(r)
         
-            for ex in tqdm(example_list[:10]):
+            for ex in tqdm(example_list):
                 file_name = ex[0]
                 if data_path.joinpath(file_name) in audio_list:
                     # Get captions

--- a/clotho_preprocessing.py
+++ b/clotho_preprocessing.py
@@ -47,7 +47,7 @@ def preprocess_dataset(config):
                     captions = [c.translate(str.maketrans('', '', string.punctuation)).lower() for c in captions]
                     
                     # Compute VGGish embeddings
-                    vggish_embeddings = vggish_model.forward(str(data_path.joinpath(file_name))).detach().numpy()
+                    vggish_embeddings = vggish_model.forward(str(data_path.joinpath(file_name))).detach().cpu().numpy()
                     
                     # Output one npy file per reference caption
                     for i_cap, caption in enumerate(captions):
@@ -69,7 +69,7 @@ def preprocess_dataset(config):
             for ex in tqdm(audio_list):
                 file_name = ex.name
                 # Compute VGGish embeddings
-                vggish_embeddings = vggish_model.forward(str(ex)).detach().numpy()
+                vggish_embeddings = vggish_model.forward(str(ex)).detach().cpu().numpy()
                 
                 # Create recarray
                 temp_rec_array = np.rec.array(np.array(


### PR DESCRIPTION
This pull request fixes two minor bugs in the clotho_preprocessing script:
- The script only iterates over ten files in the training, validation, and evaluation set. 
- If a GPU is available, the VGGish model returns a cuda tensor, which must be transferred to the CPU memory before converting it to NumPy.